### PR TITLE
Fullscreen flag needs to go before the ROM path for melonDS

### DIFF
--- a/emulators/melonds.md
+++ b/emulators/melonds.md
@@ -34,7 +34,7 @@ Open Steam ROM Manager, press Parsers, then enter the following settings:
 -   You can add additional categories to Steam category using the format `${category name}`, this is case-sensitive.
 -   Change configuration title to `Nintendo DS - melonDS` to make it less confusing.
 -   Set executable to `/usr/bin/flatpak`.
--   Set command line arguments to `run net.kuribo64.melonDS "${filePath}" -f`
+-   Set command line arguments to `run net.kuribo64.melonDS -f "${filePath}"`
 -   Set ROMs directory to wherever your DS ROMs are - if you're using the recommended path, this should be `~/roms/ds`.
 -   Press save.
 


### PR DESCRIPTION
<!---
Thanks for contributing to the guide! Make sure your PR follows the contributing guide: https://github.com/nchristopher/steamdeck-emulation/blob/main/CONTRIBUTING.md.

Please fill out this pull request template - do NOT create a blank PR.
-->

### Proposed changes

<!---
Outline changes made in this pull request, along with why they should be merged. If this PR closes any issues, link them here (eg. "Closes #5").
-->

Updated the melonDS docs to fix the placement of the fullscreen flag.
With the fullscreen flag AFTER the ROM path, a "Failed to load ROM" error occurs.
